### PR TITLE
Clarify that local aliases must start with a lowercase letter

### DIFF
--- a/steps/01/README.md
+++ b/steps/01/README.md
@@ -53,4 +53,4 @@ The line `let msg = "hello world"` creates a `String` object whose value is `"he
 
 1. The `env` object has other members besides `out`. Look at the documentation for the standard library and try to figure out how to print a message to the standard error stream instead of the standard output stream.
 2. All type names must be capitalized. What kind of error do you get if you change `Main` to `main`?
-3. All alias names must start with an `_` or a lowercase letter. What happens if you change `env` or `msg` to violate this rule?
+3. All local alias names must start with a lowercase letter. What happens if you change `env` or `msg` to violate this rule? For more information about variable naming, see the [Variables section](https://tutorial.ponylang.org/expressions/variables.html) of the Pony tutorial.


### PR DESCRIPTION
The text in Q3 of 01/README.md made it seem as though any variable
could start with an `_` character, but only fields can use `_`. I
changed the wording of the question to specifically say that local
variables must start with a lowercase letter and added a link to the
variables section of the tutorial. This should prevent unnecessary
confusion.

Closes #9