### PR TITLE
Fix code formatting in 02/README.md

### DIFF
--- a/steps/02/README.md
+++ b/steps/02/README.md
@@ -2,7 +2,7 @@
 
 This program prints out a "hello" message, where "hello" is followed by either the first argument to the program or "[unknown]" if there is no argument given to the program.
 
-```ponyc
+```pony
 actor Main
   new create(env: Env val) =>
     let name: String val = try


### PR DESCRIPTION
The code formatting wasn't working in one of the code blocks in
02/README.md because the language for the block was `ponyc` when it
should have been `pony`. This change will cause highlighting to work
again.

Closes #8